### PR TITLE
validation: fix inconsistent update of address index

### DIFF
--- a/src/undo.h
+++ b/src/undo.h
@@ -108,6 +108,7 @@ DisconnectResult ApplyTxInUndo(const CTxInUndo &undo, CCoinsViewCache &view,
  */
 DisconnectResult ApplyBlockUndo(const CBlockUndo &blockUndo,
                                 const CBlock &block, const CBlockIndex *pindex,
-                                CCoinsViewCache &coins);
+                                CCoinsViewCache &coins,
+                                bool fJustCheck = false);
 
 #endif // BITCOIN_UNDO_H


### PR DESCRIPTION
Fixes https://github.com/Bitcoin-ABC/bitcoin-abc/issues/43 / https://github.com/bitprim/bitcoin-abc/issues/1

During rebasing of the address index onto bitcoin-abc/bitcoin-abc@2f7d520, the
`pfClean` parameter was removed.  The address index code was relying on it to
update the db, which is side-effectful and not memory-only, like the rest of
the method. Running the node with `nCheckLevel == 3` would remove last
`nCheckDepth` blocks from the index.